### PR TITLE
fix: Update permissions in daily workflow and clean up environment variables; adjust import path for Strava API

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,7 +2,7 @@ name: Daily Coach Run
 
 permissions:
   contents: read
-  secrets: write
+  actions: write
 
 on:
   schedule:
@@ -31,24 +31,12 @@ jobs:
           EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
           TO_EMAIL: ${{ secrets.TO_EMAIL }}
           TO_PHONE: ${{ secrets.TO_PHONE }}
-          USE_TWILIO: ${{ secrets.USE_TWILIO }}
-          TWILIO_SID: ${{ secrets.TWILIO_SID }}
-          TWILIO_AUTH: ${{ secrets.TWILIO_AUTH }}
-          TWILIO_PHONE: ${{ secrets.TWILIO_PHONE }}
+          # USE_TWILIO: ${{ secrets.USE_TWILIO }}
+          # TWILIO_SID: ${{ secrets.TWILIO_SID }}
+          # TWILIO_AUTH: ${{ secrets.TWILIO_AUTH }}
+          # TWILIO_PHONE: ${{ secrets.TWILIO_PHONE }}
           OURA_TOKEN: ${{ secrets.OURA_TOKEN }}
           STRAVA_CLIENT_ID: ${{ secrets.STRAVA_CLIENT_ID }}
           STRAVA_CLIENT_SECRET: ${{ secrets.STRAVA_CLIENT_SECRET }}
           STRAVA_REFRESH_TOKEN: ${{ secrets.STRAVA_REFRESH_TOKEN }}
-        run: |
-          UPDATED_TOKEN=$(python scripts/daily_run.py)
-          echo "STRAVA_REFRESH_TOKEN=$UPDATED_TOKEN" >> $GITHUB_ENV
-        outputs:
-          strava_refresh_token: ${{ env.STRAVA_REFRESH_TOKEN }}
-
-      - name: Update STRAVA_REFRESH_TOKEN in GitHub Secrets
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-          REPO_OWNER: alponsirenas
-          REPO_NAME: lanterne-rouge
-          STRAVA_REFRESH_TOKEN: ${{ needs.run-daily.outputs.strava_refresh_token }}
-        run: python scripts/update_github_secret.py
+        run: python scripts/daily_run.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ python-dotenv>=1.0.0
 requests>=2.28.0
 pytest>=8.0.0
 cryptography>=42.0.0
+twilio>=8.0.0

--- a/scripts/daily_run.py
+++ b/scripts/daily_run.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from scripts.run_tour_coach import run_daily_logic
 from notify import send_email, send_sms
-from strava_api import refresh_strava_token
+from lanterne_rouge.strava_api import refresh_strava_token
 import subprocess
 
 load_dotenv()


### PR DESCRIPTION
This pull request updates the daily workflow by modifying permissions, commenting out unused secrets, simplifying the workflow logic, and fixing an import path in the `daily_run.py` script.

### Workflow updates:

* [`.github/workflows/daily.yml`](diffhunk://#diff-49aca37051e035bf25defdedef1928d2d6fa0e39d4a592891a8c74f971992f57L5-R5): Changed permissions from `secrets: write` to `actions: write` for better alignment with GitHub Actions' permission model.
* [`.github/workflows/daily.yml`](diffhunk://#diff-49aca37051e035bf25defdedef1928d2d6fa0e39d4a592891a8c74f971992f57L34-R42): Commented out Twilio-related secrets (`USE_TWILIO`, `TWILIO_SID`, `TWILIO_AUTH`, `TWILIO_PHONE`) as they are no longer in use.
* [`.github/workflows/daily.yml`](diffhunk://#diff-49aca37051e035bf25defdedef1928d2d6fa0e39d4a592891a8c74f971992f57L34-R42): Simplified the workflow by removing the step to update the `STRAVA_REFRESH_TOKEN` in GitHub Secrets and directly running the `daily_run.py` script.

### Codebase maintenance:

* [`scripts/daily_run.py`](diffhunk://#diff-cffb0eb879b5ed2771f9191ef5c68eda2f15068a7557c8a3c6ba499f0aa25f1dL10-R10): Updated the import path for `refresh_strava_token` to use the correct module (`lanterne_rouge.strava_api`).