### PR TITLE
Fix labeler config path

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -20,3 +20,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/labeler.yml"


### PR DESCRIPTION
## Summary
- explicitly pass the labeler config file path

## Testing
- `pytest -q` *(fails: command not found)*
- `flake8` *(fails: command not found)*