### PR TITLE
Allow passing MissionConfig to tour_coach

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,7 @@
 
 - **Tour Coach** (`run_tour_coach.py`):
   - Orchestrates daily update sequence. It also triggers notification delivery through the new `notify.py` layer.
+  - `tour_coach.run()` accepts an optional `MissionConfig`. If omitted, the config is loaded from `missions/tdf_sim_2025.toml` by default.
   - Includes subprocess calls for expanded Oura contributor tracking, secure GitHub secret updates using PAT with appropriate headers, and readiness/fitness metrics logging before generating the daily output.
     - Pushes updated logs and database snapshots to GitHub (GitHub‑Actions step, currently blocked by permissions ‑ see Next Steps).
 

--- a/scripts/run_tour_coach.py
+++ b/scripts/run_tour_coach.py
@@ -15,5 +15,6 @@ st.json(_mission_cfg.dict())
 
 # New function to run daily logic
 def run_daily_logic():
+    """Execute the Tour Coach logic for the day."""
     # Pass the loaded mission configuration into the tour_coach runner
     return tour_coach.run(_mission_cfg)

--- a/src/lanterne_rouge/tour_coach.py
+++ b/src/lanterne_rouge/tour_coach.py
@@ -3,7 +3,7 @@
 # data from Oura and Strava.
 
 from dotenv import load_dotenv
-from lanterne_rouge.mission_config import load_config
+from lanterne_rouge.mission_config import MissionConfig, load_config
 import sys
 import os
 from lanterne_rouge.monitor import get_oura_readiness, get_ctl_atl_tsb
@@ -26,9 +26,13 @@ def get_version():
 
 
 
-def run():
-    # Load mission configuration
-    cfg = load_config(os.getenv("MISSION_CONFIG_PATH", "missions/tdf-sim-2025.toml"))
+def run(cfg: MissionConfig | None = None):
+    """Generate the daily Tour Coach summary."""
+    # Load mission configuration lazily
+    if cfg is None:
+        cfg = load_config(
+            os.getenv("MISSION_CONFIG_PATH", "missions/tdf_sim_2025.toml")
+        )
 
     # Load agent memory
     memory = load_memory()


### PR DESCRIPTION
## Summary
- allow passing an optional `MissionConfig` into `tour_coach.run`
- add short docstring in `scripts.run_tour_coach.run_daily_logic`
- document the optional parameter in `docs/architecture.md`

## Testing
- `pytest -q` *(fails: command not found)*