### PR TITLE
Fix decide_adjustment argument

### DIFF
--- a/src/lanterne_rouge/tour_coach.py
+++ b/src/lanterne_rouge/tour_coach.py
@@ -61,7 +61,7 @@ def run(cfg: MissionConfig | None = None):
         ctl=ctl,
         atl=atl,
         tsb=tsb,
-        mission_cfg=cfg,
+        cfg=cfg,
     )
 
     # Log decision (recommendations) to memory


### PR DESCRIPTION
## Summary
- pass cfg with correct name when calling `decide_adjustment`

## Testing
- `pytest -q` *(fails: `pytest` not found)*