### PR TITLE
Improve error handling for OpenAI calls

### DIFF
--- a/src/lanterne_rouge/plan_generator.py
+++ b/src/lanterne_rouge/plan_generator.py
@@ -24,15 +24,21 @@ def generate_workout_plan(mission_cfg: MissionConfig, memory: dict):
         "Generate a workout_plan JSON matching workout_plan.schema.json. Return only the JSON object."
     )
 
-    # Call OpenAI
-    resp = openai.ChatCompletion.create(
-        model=os.getenv("OPENAI_MODEL", "gpt-4"),
-        messages=[
-            {"role": "system", "content": "You are a workout planning assistant."},
-            {"role": "user", "content": prompt},
-        ],
-        temperature=0.7,
-    )
-
-    # Parse and return
-    return json.loads(resp.choices[0].message.content)
+    # Call OpenAI with basic error handling
+    try:
+        resp = openai.ChatCompletion.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4"),
+            messages=[
+                {"role": "system", "content": "You are a workout planning assistant."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.7,
+        )
+        # Parse and return
+        return json.loads(resp.choices[0].message.content)
+    except openai.OpenAIError as e:  # pragma: no cover - depends on API
+        print(f"❌ OpenAI request failed: {e}")
+        return {}
+    except Exception as e:  # Fallback for unexpected issues
+        print(f"❌ OpenAI request failed: {e}")
+        return {}

--- a/src/lanterne_rouge/plan_generator.py
+++ b/src/lanterne_rouge/plan_generator.py
@@ -37,8 +37,8 @@ def generate_workout_plan(mission_cfg: MissionConfig, memory: dict):
         # Parse and return
         return json.loads(resp.choices[0].message.content)
     except openai.OpenAIError as e:  # pragma: no cover - depends on API
-        print(f"❌ OpenAI request failed: {e}")
+        logger.error(f"❌ OpenAI request failed: {e}")
         return {}
     except Exception as e:  # Fallback for unexpected issues
-        print(f"❌ OpenAI request failed: {e}")
+        logger.error(f"❌ OpenAI request failed: {e}")
         return {}

--- a/src/lanterne_rouge/tour_coach.py
+++ b/src/lanterne_rouge/tour_coach.py
@@ -69,7 +69,7 @@ def run(cfg: MissionConfig | None = None):
 
     # 3. Get today's workout plan via LLM-driven planner
     workout = generate_workout_plan(cfg, memory)
-    today_workout_type = workout["name"]
+    today_workout_type = workout.get("name", "No workout generated")
     today_workout_details = workout.get("description", "")
 
     # 4. Match to Peloton class

--- a/src/lanterne_rouge/tour_coach.py
+++ b/src/lanterne_rouge/tour_coach.py
@@ -69,7 +69,7 @@ def run(cfg: MissionConfig | None = None):
 
     # 3. Get today's workout plan via LLM-driven planner
     workout = generate_workout_plan(cfg, memory)
-    today_workout_type = workout.get("name", "No workout generated")
+    today_workout_type = workout.get("workout", "No workout generated")
     today_workout_details = workout.get("description", "")
 
     # 4. Match to Peloton class

--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -1,6 +1,7 @@
 import pytest
 from datetime import date
 from unittest.mock import patch, MagicMock
+import openai
 from lanterne_rouge.plan_generator import generate_workout_plan
 from lanterne_rouge.mission_config import MissionConfig, Targets, Constraints
 
@@ -39,3 +40,11 @@ def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_ope
     assert isinstance(plan, dict)
     assert plan["workout"] == "test_plan"
     mock_openai.assert_called_once()
+
+
+@patch("lanterne_rouge.plan_generator.openai.ChatCompletion.create", side_effect=openai.OpenAIError("boom"))
+@patch("lanterne_rouge.plan_generator.get_ctl_atl_tsb", return_value=(50, 40, 10))
+@patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}))
+def test_generate_workout_plan_openai_error(mock_readiness, mock_ctl_atl, mock_openai):
+    plan = generate_workout_plan(_dummy_cfg, memory={"foo": "bar"})
+    assert plan == {}


### PR DESCRIPTION
## Summary
- catch errors around the OpenAI chat completion in `generate_workout_plan`
- fall back to an empty plan object when the API fails
- allow `tour_coach.run` to continue even when no plan is returned
- test failure path for workout plan generation

## Testing
- `pytest -q`