### PR TITLE
Update readiness patch to use three-tuple

### DIFF
--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -27,7 +27,7 @@ _dummy_cfg = MissionConfig(
 
 @patch("lanterne_rouge.plan_generator.openai.ChatCompletion.create")
 @patch("lanterne_rouge.plan_generator.get_ctl_atl_tsb", return_value=(50, 40, 10))
-@patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}))
+@patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}, "2025-01-01"))
 def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_openai):
     # Prepare a fake LLM response object
     fake_message = MagicMock()
@@ -44,7 +44,7 @@ def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_ope
 
 @patch("lanterne_rouge.plan_generator.openai.ChatCompletion.create", side_effect=openai.OpenAIError("boom"))
 @patch("lanterne_rouge.plan_generator.get_ctl_atl_tsb", return_value=(50, 40, 10))
-@patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}))
+@patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}, "2025-01-01"))
 def test_generate_workout_plan_openai_error(mock_readiness, mock_ctl_atl, mock_openai):
     plan = generate_workout_plan(_dummy_cfg, memory={"foo": "bar"})
     assert plan == {}


### PR DESCRIPTION
## Summary
- adjust mocks in `test_plan_generator.py` to return the new three-field readiness tuple

## Testing
- `pytest -q` *(fails: ValueError too many values to unpack)*