### PR TITLE
Update docs with new components

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Lanterne Rouge integrates data from your Oura Ring and Strava to understand your
 
 By integrating with your existing tools, Lanterne Rouge helps you stay consistent without adding complexity. Whether you follow structured workouts, use cycling platforms, or ride by feel, the application adapts to keep you moving forward.
 
+All observations and decisions are stored in a lightweight SQLite database (`src/lanterne_rouge/memory/lanterne.db`).
+This memory lets the LLM‑powered planner reference recent history when crafting each day’s workout.
+
 ## Getting Started
 
 Follow these steps to set up Lanterne Rouge:

--- a/context/ai_integration.md
+++ b/context/ai_integration.md
@@ -130,7 +130,7 @@ lanterne-rouge/
 | Daily Run Frequency           | 1 time per day                              |
 | Data Sources                  | Oura API, Strava API (both free for personal use) |
 | Reasoning Module              | LLM-assisted lightweight reasoning text generation |
-| Communication                 | Gradio dashboard or simple output logging    |
+| Communication                 | Streamlit dashboard or simple output logging |
 | Hosting                       | Tiny server (VPS or serverless)              |
 
 

--- a/context/github_project_structure.md
+++ b/context/github_project_structure.md
@@ -19,7 +19,7 @@ Initial Cards
 Title	Type	Notes
 Create and Integrate MissionConfig v1.0	Issue	Define simulation goals, fitness targets, stage demands.
 Build Reasoning Module v1.0	Issue	Enable daily decision-making aligned to MissionConfig.
-Build Initial GUI Using Gradio	Issue	Display daily readiness, decision, and explanations.
+Build Initial GUI Using Streamlit	Issue	Display daily readiness, decision, and explanations.
 Integrate First LLM for Explanations	Issue	Generate human-readable coaching summaries after reasoning decisions.
 Expand Oura Contributor Logging	Issue	Capture full readiness contributor data for future reasoning improvements.
 

--- a/context/lanterne_rouge_agent_team_prompts.md
+++ b/context/lanterne_rouge_agent_team_prompts.md
@@ -16,12 +16,12 @@ Lanterne Rouge is an agentic AI system for endurance athletes inspired by the la
 **Current Target: v0.3.0 — Mission-Aware Daily Coaching**
 - MissionConfig v1
 - Reasoning Module v1
-- Gradio GUI v1
+ - Streamlit UI v0.1
 - Natural language coaching summaries via LLM
 - Expanded readiness inputs (Oura)
 
 **Core Modules:**
-- `mission_config.py`, `reasoner.py`, `memory_bus.py`, `run_tour_coach.py`, `gui.py`, `ai_clients.py`
+ - `mission_config.py`, `reasoner.py`, `memory_bus.py`, `scripts/run_tour_coach.py`, `ai_clients.py`
 
 **Memory System:**
 - Logs observations (e.g., readiness, CTL, TSB)
@@ -79,12 +79,12 @@ You are the **UX Designer** for Lanterne Rouge.
 Your job is to design a seamless, transparent experience for athletes. You ensure that decision summaries are understandable, the interface supports trust, and the dashboard communicates the right data at the right moment.
 
 **You specialize in:**
-- Gradio dashboards and CLI experience
+ - Streamlit dashboards and CLI experience
 - Designing for explainability in AI decisions
 - Minimalist, motivation-oriented UX for athletes
 
 **Current responsibilities:**
-- Design the v0.3.0 Gradio GUI showing the daily recommendation, readiness state, and summary explanation.
+ - Design the v0.3.0 Streamlit UI showing the daily recommendation, readiness state, and summary explanation.
 - Improve the flow from `run_tour_coach.py` execution to user understanding.
 - Collaborate on visualizing logs and trends.
 

--- a/context/lanterne_rouge_initial_team.md
+++ b/context/lanterne_rouge_initial_team.md
@@ -20,12 +20,12 @@ Lanterne Rouge is an agentic AI system for endurance athletes inspired by the la
 **Current Target: v0.3.0 — Mission-Aware Daily Coaching**
 - MissionConfig v1
 - Reasoning Module v1
-- Gradio GUI v1
+ - Streamlit UI v0.1
 - Natural language coaching summaries via LLM
 - Expanded readiness inputs (Oura)
 
 **Core Modules:**
-- `mission_config.py`, `reasoner.py`, `memory_bus.py`, `run_tour_coach.py`, `gui.py`, `ai_clients.py`
+ - `mission_config.py`, `reasoner.py`, `memory_bus.py`, `scripts/run_tour_coach.py`, `ai_clients.py`
 
 **Memory System:**
 - Logs observations (e.g., readiness, CTL, TSB)
@@ -73,7 +73,7 @@ You are the **UX Designer** for Lanterne Rouge.
 Your job is to design a seamless, transparent experience for athletes. You ensure that decision summaries are understandable, the interface supports trust, and the dashboard communicates the right data at the right moment.
 
 **Current responsibilities:**
-- Design the v0.3.0 Gradio GUI showing the daily recommendation, readiness state, and summary explanation.
+ - Design the v0.3.0 Streamlit UI showing the daily recommendation, readiness state, and summary explanation.
 - Improve the flow from `run_tour_coach.py` execution to user understanding.
 - Collaborate on visualizing logs and trends.
 

--- a/context/primer.md
+++ b/context/primer.md
@@ -48,22 +48,22 @@ Build an agentic AI system that adapts endurance training dynamically based on r
     reasoner.py
     strava_api.py
     tour_coach.py
-    update_github_secret.py
-    daily_run.py
+    ai_clients.py
+    memory_bus.py
 /config/             # templates or examples of MissionConfig files
     mission_config.toml   # example or template MissionConfig file
 /missions/
     *.toml          # individual MissionConfig files
-/ui/
-    streamlit_app.py
+/scripts/
+    run_tour_coach.py
+    daily_run.py
+    notify.py
+    update_github_secret.py
 /output/
     tour_coach_update.txt
     readiness_score_log.csv
     reasoning_log.csv
     lanterne.db
-/scripts/
-    update_github_secret.py
-    daily_run.py
 ```
 
 ---
@@ -72,11 +72,11 @@ Build an agentic AI system that adapts endurance training dynamically based on r
 
 | Agent Name          | Responsibility                                                                 | Related Modules                      |
 |---------------------|----------------------------------------------------------------------------------|--------------------------------------|
-| Tour Coach Agent    | Summarizes daily readiness, generates training recommendations                  | `tour_coach.py`, `daily_run.py`     |
-| Reasoning Agent     | Aligns observations with MissionConfig to make actionable decisions              | `reasoner.py`, `plan_generator.py`  |
-| GitHubOps Agent     | Updates secrets and interacts with GitHub programmatically                      | `update_github_secret.py`           |
+| Tour Coach Agent    | Summarizes daily readiness, generates training recommendations                  | `tour_coach.py`, `scripts/run_tour_coach.py`, `daily_run.py` |
+| Reasoning Agent     | Aligns observations with MissionConfig to make actionable decisions              | `reasoner.py`, `plan_generator.py`, `ai_clients.py` |
+| GitHubOps Agent     | Updates secrets and interacts with GitHub programmatically                      | `scripts/update_github_secret.py`   |
 | Monitor Agent       | Pulls Oura and Strava data, calculates readiness and fitness baselines           | `monitor.py`, `strava_api.py`       |
-| UI Agent (Streamlit) | Renders daily summaries and charts for humans | `ui/streamlit_app.py` |
+| UI Agent (Streamlit) | Renders daily summaries and charts for humans | `scripts/run_tour_coach.py` |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,16 @@
   - Analyzes observations and recommends daily action.
   - Aligned with MissionConfig.
 
+- **Workout Plan Generator** (`plan_generator.py`):
+  - Uses OpenAI via `ai_clients.py` to create a daily workout plan.
+
+- **Peloton Matcher** (`peloton_matcher.py`):
+  - Suggests a matching Peloton class for the generated workout type.
+
+- **Memory Layer** (`memory_bus.py`):
+  - Stores observations, decisions, and reflections in `memory/lanterne.db`.
+  - Provides recent context for LLM prompts.
+
 - **Output Layer**:
   - Saves reports and logs into `/output/`.
 


### PR DESCRIPTION
## Summary
- update architecture doc with memory bus and planning components
- refresh context repo layout and agent roles
- replace old Gradio references with Streamlit
- document memory DB in README

## Testing
- `pytest -q` *(fails: No module named pytest)*