### PR TITLE
Switch to new OpenAI client style

### DIFF
--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -115,7 +115,7 @@ def call_llm(
     Returns:
         The assistant's reply content.
     """
-    response = openai.ChatCompletion.create(
+    response = openai.chat.completions.create(
         model=model,
         messages=messages,
         temperature=temperature,

--- a/src/lanterne_rouge/plan_generator.py
+++ b/src/lanterne_rouge/plan_generator.py
@@ -29,7 +29,7 @@ def generate_workout_plan(mission_cfg: MissionConfig, memory: dict):
 
     # Call OpenAI with basic error handling
     try:
-        resp = openai.ChatCompletion.create(
+        resp = openai.chat.completions.create(
             model=os.getenv("OPENAI_MODEL", "gpt-4"),
             messages=[
                 {"role": "system", "content": "You are a workout planning assistant."},

--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -25,10 +25,11 @@ _dummy_cfg = MissionConfig(
     ),
 )
 
-@patch("lanterne_rouge.plan_generator.openai.ChatCompletion.create")
+@patch("lanterne_rouge.plan_generator.openai.resources.chat.completions.Completions.create")
 @patch("lanterne_rouge.plan_generator.get_ctl_atl_tsb", return_value=(50, 40, 10))
 @patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}, "2025-01-01"))
 def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_openai):
+    openai.api_key = "test-key"
     # Prepare a fake LLM response object
     fake_message = MagicMock()
     fake_message.content = '{"workout":"test_plan"}'
@@ -42,9 +43,10 @@ def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_ope
     mock_openai.assert_called_once()
 
 
-@patch("lanterne_rouge.plan_generator.openai.ChatCompletion.create", side_effect=openai.OpenAIError("boom"))
+@patch("lanterne_rouge.plan_generator.openai.resources.chat.completions.Completions.create", side_effect=openai.OpenAIError("boom"))
 @patch("lanterne_rouge.plan_generator.get_ctl_atl_tsb", return_value=(50, 40, 10))
 @patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}, "2025-01-01"))
 def test_generate_workout_plan_openai_error(mock_readiness, mock_ctl_atl, mock_openai):
+    openai.api_key = "test-key"
     plan = generate_workout_plan(_dummy_cfg, memory={"foo": "bar"})
     assert plan == {}


### PR DESCRIPTION
## Summary
- migrate to `openai.chat.completions.create` calls
- update unit tests to patch the new path
- adjust tests to set dummy api key

## Testing
- `pytest -q`