### PR TITLE
Standardize memory DB path

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -47,7 +47,7 @@ jobs:
           add: |
             output/*.txt
             output/*.csv
-            lanterne.db
+            memory/lanterne.db
           author_name: lanterne-rouge-bot
           author_email: bot@users.noreply.github.com
           message: 'chore(data): daily coach output [skip ci]'

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ __pycache__/
 tokens.json
 
 # SQLite database
-lanterne.db
-memory/lanterne.db
+# (tracked by default)
 
 # MacOS system files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lanterne Rouge integrates data from your Oura Ring and Strava to understand your
 
 By integrating with your existing tools, Lanterne Rouge helps you stay consistent without adding complexity. Whether you follow structured workouts, use cycling platforms, or ride by feel, the application adapts to keep you moving forward.
 
-All observations and decisions are stored in a lightweight SQLite database (`src/lanterne_rouge/memory/lanterne.db`).
+All observations and decisions are stored in a lightweight SQLite database (`memory/lanterne.db`).
 This memory lets the LLM‑powered planner reference recent history when crafting each day’s workout.
 
 ## Getting Started
@@ -46,7 +46,7 @@ Follow these steps to set up Lanterne Rouge:
    ```bash
    python -c "from lanterne_rouge.mission_config import bootstrap; bootstrap('missions/tdf_sim_2025.toml')"
    ```
-   This creates `lanterne.db` seeded with your mission config. It will also be generated automatically the first time you run `daily_run.py`.
+   This creates `memory/lanterne.db` seeded with your mission config. It will also be generated automatically the first time you run `daily_run.py`.
 
 5. **Configure your `.env` file with your API credentials and notification settings:**
 

--- a/context/primer.md
+++ b/context/primer.md
@@ -13,7 +13,7 @@ Build an agentic AI system that adapts endurance training dynamically based on r
 - Reasoning Module: Decides daily actions based on observations and mission alignment.
 - Planning Module: Updates training calendar dynamically.
 - Communication Layer: Presents updates via Streamlit UI (Gradio prototype retired).
-- Storage Layer: Persists mission configs, readiness logs, and plan state to SQLite (lanterne.db).
+- Storage Layer: Persists mission configs, readiness logs, and plan state to SQLite (`memory/lanterne.db`).
 - Reflection Layer (future): Learns from past decision outcomes.
 - GitHub Integration Layer: Manages repository secrets programmatically via secure API calls
 
@@ -35,7 +35,7 @@ Build an agentic AI system that adapts endurance training dynamically based on r
     • Streamlit UI v0.1.0 for daily summaries & charts  
     • Full Oura contributor logging (completed)  
     • Secure GitHub secret rotation via `GH_PAT` (completed)  
-    • Persist outputs to `lanterne.db` and push to repo nightly
+    • Persist outputs to `memory/lanterne.db` and push to repo nightly
 
 ## Repository Layout
 
@@ -63,7 +63,7 @@ Build an agentic AI system that adapts endurance training dynamically based on r
     tour_coach_update.txt
     readiness_score_log.csv
     reasoning_log.csv
-    lanterne.db
+    memory/lanterne.db
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@
 - **MissionConfig** (`mission_config.py`):
   - Loads structured simulation goals and constraints from TOML (`missions/*.toml`).
   - Supports runtime overrides from environment secrets (e.g. `STRAVA_CLIENT_ID`).
-  - Persists the active config into SQLite (`lanterne.db`) via `cache_to_sqlite()` for reproducibility.
+  - Persists the active config into SQLite (`memory/lanterne.db`) via `cache_to_sqlite()` for reproducibility.
 
 - **Observation Layer** (`monitor.py`):
   - Gathers data from Oura and Strava APIs.
@@ -50,7 +50,7 @@
 - **update_github_secret.py**:
   - Uses the GitHub API to programmatically update repository secrets.
   - Requires a Personal Access Token (PAT) with `repo` and `actions` scopes.
-  - Now explicitly includes both `Authorization` and `User-Agent` headers in API requests. The workflow now attempts to commit updated `/output/` artifacts and `lanterne.db` back to the repo; this requires the PAT to have `contents:write` (or use a deploy key) — currently blocked by 403 errors.
+  - Now explicitly includes both `Authorization` and `User-Agent` headers in API requests. The workflow now attempts to commit updated `/output/` artifacts and `memory/lanterne.db` back to the repo; this requires the PAT to have `contents:write` (or use a deploy key) — currently blocked by 403 errors.
 
 ### Next Steps toward v0.3.0 Release
 

--- a/src/lanterne_rouge/memory_bus.py
+++ b/src/lanterne_rouge/memory_bus.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sqlite3
 import json
 
-DB_FILE = Path(__file__).parent.parent / "memory" / "lanterne.db"
+DB_FILE = Path(__file__).resolve().parents[2] / "memory" / "lanterne.db"
 DB_FILE.parent.mkdir(parents=True, exist_ok=True)
 
 _conn = sqlite3.connect(DB_FILE)

--- a/src/lanterne_rouge/mission_config.py
+++ b/src/lanterne_rouge/mission_config.py
@@ -83,7 +83,7 @@ def load_config(path: Path | str) -> MissionConfig:
 # Cache Layer (SQLite for v0.3)
 # ──────────────────────────────────────────────────────────────────────────────
 
-def cache_to_sqlite(cfg: MissionConfig, db_path: str | Path = "lanterne.db") -> None:
+def cache_to_sqlite(cfg: MissionConfig, db_path: str | Path = "memory/lanterne.db") -> None:
     """Upsert the JSON blob so other modules can query cheaply."""
     db_path = Path(db_path)
     con = sqlite3.connect(db_path)
@@ -104,7 +104,7 @@ def cache_to_sqlite(cfg: MissionConfig, db_path: str | Path = "lanterne.db") -> 
 
 # Convenience – load + cache in one call
 
-def bootstrap(path: Path | str, db_path: str | Path = "lanterne.db") -> MissionConfig:
+def bootstrap(path: Path | str, db_path: str | Path = "memory/lanterne.db") -> MissionConfig:
     cfg = load_config(path)
     cache_to_sqlite(cfg, db_path)
     return cfg


### PR DESCRIPTION
## Summary
- stop ignoring `memory/lanterne.db`
- fix path references in README and docs
- update workflow to commit the new DB location
- use `memory/lanterne.db` for MissionConfig caching
- locate the memory database relative to the repo root

## Testing
- `pytest -q`