### PR TITLE
Ensure workout plan JSON validity

### DIFF
--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -32,14 +32,14 @@ def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_ope
     openai.api_key = "test-key"
     # Prepare a fake LLM response object
     fake_message = MagicMock()
-    fake_message.content = '{"workout":"test_plan"}'
+    fake_message.content = '{"workouts": ["test_plan"]}'
     fake_choice = MagicMock()
     fake_choice.message = fake_message
     mock_openai.return_value = MagicMock(choices=[fake_choice])
 
     plan = generate_workout_plan(_dummy_cfg, memory={"foo":"bar"})
     assert isinstance(plan, dict)
-    assert plan["workout"] == "test_plan"
+    assert plan["workouts"] == ["test_plan"]
     mock_openai.assert_called_once()
 
 
@@ -59,14 +59,29 @@ def test_generate_workout_plan_prints_messages(mock_readiness, mock_ctl_atl, moc
     openai.api_key = "test-key"
     # Prepare a fake LLM response object
     fake_message = MagicMock()
-    fake_message.content = '{"workout":"test_plan"}'
+    fake_message.content = '{"workouts": ["test_plan"]}'
     fake_choice = MagicMock()
     fake_choice.message = fake_message
     mock_openai.return_value = MagicMock(choices=[fake_choice])
 
     plan = generate_workout_plan(_dummy_cfg, memory={"foo":"bar"})
     assert isinstance(plan, dict)
-    assert plan["workout"] == "test_plan"
+    assert plan["workouts"] == ["test_plan"]
     mock_openai.assert_called_once()
     mock_print.assert_any_call("Generating workout plan...")
     mock_print.assert_any_call("Workout plan generated successfully")
+
+
+@patch("lanterne_rouge.plan_generator.openai.resources.chat.completions.Completions.create")
+@patch("lanterne_rouge.plan_generator.get_ctl_atl_tsb", return_value=(50, 40, 10))
+@patch("lanterne_rouge.plan_generator.get_oura_readiness", return_value=(80, {}, "2025-01-01"))
+def test_generate_workout_plan_missing_workouts(mock_readiness, mock_ctl_atl, mock_openai):
+    openai.api_key = "test-key"
+    fake_message = MagicMock()
+    fake_message.content = '{"foo": "bar"}'
+    fake_choice = MagicMock()
+    fake_choice.message = fake_message
+    mock_openai.return_value = MagicMock(choices=[fake_choice])
+
+    with pytest.raises(ValueError):
+        generate_workout_plan(_dummy_cfg, memory={"foo": "bar"})


### PR DESCRIPTION
## Summary
- improve prompts for workout plan generation
- enforce JSON response using OpenAI `response_format`
- validate that `workouts` key exists before returning
- adjust tests for new JSON format and failure mode

## Testing
- `pytest -q`