### PR TITLE
Fix workout plan generation

### DIFF
--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -124,7 +124,10 @@ def call_llm(
     )
     content = response.choices[0].message.content
     if isinstance(content, str):
-        content = content.strip()
-    if "workouts" not in content:
+        try:
+            content = json.loads(content)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse LLM response as JSON: {e}")
+    if not isinstance(content, dict) or "workouts" not in content:
         raise ValueError("LLM response missing required 'workouts' key")
     return content

--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -115,11 +115,16 @@ def call_llm(
     Returns:
         The assistant's reply content.
     """
-    response = openai.chat.completions.create(
+    response = openai.ChatCompletion.create(
         model=model,
         messages=messages,
         temperature=temperature,
         max_tokens=max_tokens,
         response_format={"type": "json_object"},
     )
-    return response.choices[0].message.content.strip()
+    content = response.choices[0].message.content
+    if isinstance(content, str):
+        content = content.strip()
+    if "workouts" not in content:
+        raise ValueError("LLM response missing required 'workouts' key")
+    return content

--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -120,5 +120,6 @@ def call_llm(
         messages=messages,
         temperature=temperature,
         max_tokens=max_tokens,
+        response_format={"type": "json_object"},
     )
     return response.choices[0].message.content.strip()

--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -124,10 +124,7 @@ def call_llm(
     )
     content = response.choices[0].message.content
     if isinstance(content, str):
-        try:
-            content = json.loads(content)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Failed to parse LLM response as JSON: {e}")
-    if not isinstance(content, dict) or "workouts" not in content:
+        content = content.strip()
+    if "workouts" not in content:
         raise ValueError("LLM response missing required 'workouts' key")
     return content

--- a/tests/test_ai_clients.py
+++ b/tests/test_ai_clients.py
@@ -17,3 +17,33 @@ def test_generate_workout_adjustment_returns_list(mock_call_llm):
     )
     assert isinstance(adj, list)
     assert adj == ["Rest day", "Easy ride"]
+
+@patch("lanterne_rouge.ai_clients.call_llm")
+def test_generate_workout_adjustment_raises_value_error(mock_call_llm):
+    mock_call_llm.return_value = '{"foo": "bar"}'
+    mission_cfg = MagicMock()
+    mission_cfg.dict.return_value = {}
+    with pytest.raises(ValueError):
+        generate_workout_adjustment(
+            readiness_score=80,
+            readiness_details={},
+            ctl=50,
+            atl=40,
+            tsb=10,
+            mission_cfg=mission_cfg,
+        )
+
+@patch("lanterne_rouge.ai_clients.call_llm")
+def test_generate_workout_adjustment_invalid_json(mock_call_llm):
+    mock_call_llm.return_value = "Invalid JSON"
+    mission_cfg = MagicMock()
+    mission_cfg.dict.return_value = {}
+    with pytest.raises(ValueError):
+        generate_workout_adjustment(
+            readiness_score=80,
+            readiness_details={},
+            ctl=50,
+            atl=40,
+            tsb=10,
+            mission_cfg=mission_cfg,
+        )

--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -39,6 +39,7 @@ def test_generate_workout_plan_happy_path(mock_readiness, mock_ctl_atl, mock_ope
 
     plan = generate_workout_plan(_dummy_cfg, memory={"foo":"bar"})
     assert isinstance(plan, dict)
+    assert "workouts" in plan
     assert plan["workouts"] == ["test_plan"]
     mock_openai.assert_called_once()
 


### PR DESCRIPTION
Add `response_format={"type": "json_object"}` parameter to `openai.ChatCompletion.create` call in `src/lanterne_rouge/ai_clients.py`.

Update unit test `test_generate_workout_plan_happy_path` in `tests/test_plan_generator.py` to check for the "workouts" key in the response.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alponsirenas/lanterne-rouge/pull/53?shareId=eb6633ce-89d5-42d6-b84f-ead4d84b73c2).