### PR TITLE
Fix try block and syntax error in ai_clients and test_reasoner

### DIFF
--- a/tests/test_reasoner.py
+++ b/tests/test_reasoner.py
@@ -61,4 +61,4 @@ def test_multiple_assertions():
 
     messages = decide_adjustment(80, {"hrv_balance": 90}, 80, 70, 15, _dummy_cfg)
     assert any("Form is highly positive" in m for m in messages)
-    assert any("Chronic fitness (CTL > 70) is excellent" in m for in messages)
+    assert any("Chronic fitness (CTL > 70) is excellent" in m for m in messages)


### PR DESCRIPTION
Fix the syntax error in the list comprehension in `tests/test_reasoner.py`.

* Specify the iteration variable `m` in the list comprehension to correct the syntax error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alponsirenas/lanterne-rouge/pull/61?shareId=bf53a26e-7921-4de5-920a-8b6287ddc288).