### PR TITLE
Fix AI parsing and reasoner thresholds

### DIFF
--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -76,15 +76,22 @@ def generate_workout_adjustment(
     )
     messages.append({"role": "user", "content": user_content})
 
-    try:
-        raw_response = call_llm(messages)
-        # Add a check to ensure the response is a valid JSON string
-        json.loads(raw_response)
-    except json.JSONDecodeError:
-        raise ValueError("Invalid JSON response from LLM")
+    raw_response = call_llm(messages)
 
-    # Split the raw LLM response into individual recommendation lines.
-    # The model might return a block of text with newlines or bullets.
+    # The LLM may return either a bullet list or a JSON array of strings.
+    # Attempt JSON parsing first; fall back to bullet parsing if that fails.
+    try:
+        parsed = json.loads(raw_response)
+        if isinstance(parsed, list):
+            lines = [str(line).strip("- \t") for line in parsed if str(line).strip()]
+            return lines
+        raise ValueError("Invalid JSON response from LLM")
+    except json.JSONDecodeError:
+        # If the response doesn't look like a bullet list either, treat it as invalid
+        if not raw_response.strip().startswith("-"):
+            raise ValueError("Invalid JSON response from LLM")
+
+    # Parse simple bullet/text list
     lines = parse_llm_list(raw_response)
     return lines
 

--- a/src/lanterne_rouge/reasoner.py
+++ b/src/lanterne_rouge/reasoner.py
@@ -44,10 +44,9 @@ def decide_adjustment(
         )
 
     # 2. TSB (Form) Checks
-    if tsb < cfg.constraints.min_tsb * 2:
+    if tsb <= cfg.constraints.min_tsb * 2:
         recommendations.append(
-            "🚨 Form is very negative (TSB < -20). Strongly recommend easier or "
-            "recovery day."
+            "🚨 Form is very negative (TSB < -20). Strongly recommend easier or recovery day."
         )
     elif tsb < cfg.constraints.min_tsb:
         recommendations.append(
@@ -66,7 +65,7 @@ def decide_adjustment(
             "⚠️ Chronic fitness level (CTL) is relatively low (<30). Gradually "
             "build volume."
         )
-    elif ctl > cfg.targets.ctl_peak * 0.9:
+    elif ctl > cfg.targets.ctl_peak * 0.7:
         recommendations.append(
             "✅ Chronic fitness (CTL > 70) is excellent. Maintain consistency."
         )


### PR DESCRIPTION
## Summary
- allow bullet-list or JSON responses from AI client
- treat non-list AI responses as invalid
- adjust TSB threshold logic and fix message spacing
- lower CTL fitness threshold to match tests

## Testing
- `pytest -q`