### PR TITLE
Add configurable OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Follow these steps to set up Lanterne Rouge:
    STRAVA_CLIENT_SECRET=your_strava_client_secret
    STRAVA_REFRESH_TOKEN=your_strava_refresh_token
 
+   # OpenAI
+   OPENAI_API_KEY=your_openai_api_key
+   # Optional: override the default model
+   OPENAI_MODEL=gpt-4
+
    # Notification settings
    EMAIL_ADDRESS=your_email_address_for_notifications
    EMAIL_PASS=your_email_app_password

--- a/src/lanterne_rouge/ai_clients.py
+++ b/src/lanterne_rouge/ai_clients.py
@@ -14,7 +14,9 @@ def generate_workout_adjustment(
     atl: float,
     tsb: float,
     mission_cfg,
-    memories_limit: int = 5
+    memories_limit: int = 5,
+    *,
+    model: str | None = None,
 ) -> list[str]:
     """
     Generate workout adjustment using LLM, seeded with recent memories.
@@ -27,6 +29,8 @@ def generate_workout_adjustment(
         tsb: current Training Stress Balance.
         mission_cfg: your MissionConfig instance (to extract plan targets).
         memories_limit: how many past memories to include.
+        model: Optional model name to pass to the LLM. If omitted, the
+            default from ``call_llm`` will be used.
 
     Returns:
         List of GPT-written adjustment recommendation lines. Each line has leading hyphens and whitespace stripped.
@@ -76,7 +80,7 @@ def generate_workout_adjustment(
     )
     messages.append({"role": "user", "content": user_content})
 
-    raw_response = call_llm(messages)
+    raw_response = call_llm(messages, model=model)
 
     # The LLM may return either a bullet list or a JSON array of strings.
     # Attempt JSON parsing first; fall back to bullet parsing if that fails.
@@ -115,22 +119,26 @@ def parse_llm_list(raw_response: str) -> list[str]:
 
 def call_llm(
     messages: list[dict],
-    model: str = "gpt-4", 
-    temperature: float = 0.7, 
-    max_tokens: int = 512
+    model: str | None = None,
+    temperature: float = 0.7,
+    max_tokens: int = 512,
 ) -> str:
     """
     Send a chat completion request to the OpenAI API.
 
     Args:
         messages: A list of message dicts, each with 'role' ('system', 'user', 'assistant') and 'content'.
-        model: The OpenAI model to use (default 'gpt-4').
+        model: The OpenAI model to use. Defaults to the value of the
+            ``OPENAI_MODEL`` environment variable or ``"gpt-4"`` if unset.
         temperature: Sampling temperature (default 0.7).
         max_tokens: Maximum number of tokens in the response (default 512).
 
     Returns:
         The assistant's reply content.
     """
+    if model is None:
+        model = os.getenv("OPENAI_MODEL", "gpt-4")
+
     response = openai.resources.chat.completions.Completions.create(
         model=model,
         messages=messages,


### PR DESCRIPTION
## Summary
- let `call_llm` read default model from `OPENAI_MODEL`
- allow `generate_workout_adjustment` to forward a model argument
- document `OPENAI_MODEL` in README

## Testing
- `pytest -q`