### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,10 +14,10 @@ jobs:
   run-daily:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: Install dependencies


### PR DESCRIPTION
Update GitHub Actions workflow files to use the latest versions of actions.

* **daily.yml**
  - Update `actions/checkout` to `v4`
  - Update `actions/setup-python` to `v5`

* **pylint.yml**
  - Update `actions/setup-python` to `v4`

* **python-app.yml**
  - Update `actions/checkout` to `v4`
  - Update `actions/setup-python` to `v4`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/alponsirenas/lanterne-rouge/pull/67?shareId=78307247-dd08-45a8-95f6-17092f99ddc2).