### PR TITLE
Score rides by power zones, walks by heart rate

### DIFF
--- a/run_morning.py
+++ b/run_morning.py
@@ -205,7 +205,7 @@ def main():
     if y_stage:
         y_detail, y_via = monitor.activity_for(yesterday)
         if y_detail:
-            y_tiz = monitor.time_in_zone(y_detail["id"], monitor.hr_zones())
+            y_tiz = monitor.time_in_zone(y_detail["id"], y_via)
         y_oura = monitor.readiness_for(yesterday)
         y_hit = reason.hit_target(y_stage["targets"], y_tiz) if y_detail else False
         print(f"Stage {y_stage['n']} yesterday: "

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -99,45 +99,55 @@ def activity_for(day: date):
     return strava_get(f"activities/{best['id']}"), via
 
 
-def hr_zones() -> list[dict] | None:
-    """The athlete's Strava heart-rate zones, a list of {min, max} dicts.
-    Returns None when the token lacks the profile:read_all scope, the stage
-    then finishes without zone context rather than crashing the morning run."""
-    try:
-        return strava_get("athlete/zones")["heart_rate"]["zones"]
-    except requests.RequestException as exc:
-        print(f"Could not fetch athlete zones (needs profile:read_all scope): {exc}")
-        return None
+def time_in_zone(activity_id: int, via: str) -> dict | None:
+    """Minutes per zone from the activity streams, or None without usable data.
 
-
-def time_in_zone(activity_id: int, zones: list[dict] | None) -> dict | None:
-    """Minutes per HR zone from the activity streams, or None without HR data."""
-    if not zones:
-        return None
+    The ride prescriptions are power blocks, so a ride is scored against the
+    athlete's Strava power zones over the watts stream. A walk has no power,
+    its zones are heart-rate based. A ride missing power zones or a watts
+    stream falls back to heart rate rather than finishing without context.
+    """
     try:
+        athlete_zones = strava_get("athlete/zones")
         streams = strava_get(f"activities/{activity_id}/streams", {
-            "keys": "time,heartrate",
+            "keys": "time,heartrate,watts",
             "key_by_type": "true",
         })
     except requests.RequestException as exc:
-        print(f"Could not fetch streams for activity {activity_id}: {exc}")
+        print(f"Could not fetch zones or streams for activity {activity_id} "
+              f"(zones need the profile:read_all scope): {exc}")
         return None
-    if "time" not in streams or "heartrate" not in streams:
+    if "time" not in streams:
         return None
-    times = streams["time"]["data"]
-    hrs = streams["heartrate"]["data"]
-    seconds = [0.0] * len(zones)
+    plans = [("power", "watts"), ("heart_rate", "heartrate")] if via == "ride" \
+        else [("heart_rate", "heartrate")]
+    for kind, stream_key in plans:
+        zones = (athlete_zones.get(kind) or {}).get("zones")
+        if zones and stream_key in streams:
+            if (kind, stream_key) != plans[0]:
+                print(f"Activity {activity_id}: no power zones or watts stream, "
+                      "scoring against heart rate instead.")
+            return minutes_in_zone(streams["time"]["data"], streams[stream_key]["data"], zones)
+    return None
+
+
+def minutes_in_zone(times: list, values: list, zones: list[dict]) -> dict:
+    """Bucket a stream into the contract's z1-z5 minutes. Strava power zones can
+    run past five (Coggan has seven), everything above z5 folds into z5."""
+    seconds = [0.0] * 5
     for i in range(1, len(times)):
         dt = times[i] - times[i - 1]
         if dt <= 0 or dt > 60:  # skip pauses
             continue
-        hr = hrs[i]
+        val = values[i]
+        if val is None:
+            continue
         for z, zone in enumerate(zones):
             zmax = zone.get("max", -1)
-            if hr <= zmax or zmax == -1:
-                seconds[z] += dt
+            if val <= zmax or z == len(zones) - 1:  # last zone is open-ended
+                seconds[min(z, 4)] += dt
                 break
-    return {ZONE_KEYS[i]: round(seconds[i] / 60) for i in range(min(len(zones), 5))}
+    return {ZONE_KEYS[i]: round(seconds[i] / 60) for i in range(5)}
 
 
 def strava_summary(detail: dict, tiz: dict | None, via: str) -> dict:

--- a/tests/test_2026_morning.py
+++ b/tests/test_2026_morning.py
@@ -8,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import run_morning as rm  # noqa: E402
+import monitor  # noqa: E402
 
 MISSION = rm.load_mission()
 
@@ -67,6 +68,65 @@ def test_missed_entry_matches_contract():
     assert entry["verdict"]["call"] == "recover"
     assert entry["verdict"]["hit_target"] is False
     assert entry["verdict"]["note"]
+
+
+HR_ZONES = [{"min": 0, "max": 115}, {"min": 115, "max": 135}, {"min": 135, "max": 155},
+            {"min": 155, "max": 175}, {"min": 175, "max": -1}]
+POWER_ZONES = [{"min": 0, "max": 55}, {"min": 55, "max": 75}, {"min": 75, "max": 90},
+               {"min": 90, "max": 105}, {"min": 105, "max": 120},
+               {"min": 120, "max": 150}, {"min": 150, "max": -1}]
+
+
+def test_minutes_in_zone_buckets_per_zone():
+    times = list(range(0, 181, 60))  # three one-minute samples
+    values = [0, 50, 80, 110]  # first sample carries no time
+    tiz = monitor.minutes_in_zone(times, values, POWER_ZONES)
+    assert tiz == {"z1": 1, "z2": 0, "z3": 1, "z4": 0, "z5": 1}
+
+
+def test_minutes_in_zone_folds_high_power_zones_into_z5():
+    times = list(range(0, 181, 60))
+    values = [0, 130, 200, 200]  # z6 and the open-ended z7 both land in z5
+    tiz = monitor.minutes_in_zone(times, values, POWER_ZONES)
+    assert tiz == {"z1": 0, "z2": 0, "z3": 0, "z4": 0, "z5": 3}
+
+
+def test_minutes_in_zone_skips_pauses_and_gaps():
+    times = [0, 60, 120, 720]  # a ten-minute pause at the end
+    values = [140, 140, None, 140]
+    tiz = monitor.minutes_in_zone(times, values, HR_ZONES)
+    assert tiz == {"z1": 0, "z2": 0, "z3": 1, "z4": 0, "z5": 0}
+
+
+def _fake_strava(zones: dict, streams: dict):
+    def fake(endpoint, params=None):
+        return zones if endpoint == "athlete/zones" else streams
+    return fake
+
+
+STREAMS = {
+    "time": {"data": [0, 60, 120]},
+    "heartrate": {"data": [120, 120, 160]},
+    "watts": {"data": [60, 60, 130]},
+}
+
+
+def test_ride_uses_power_zones(monkeypatch):
+    monkeypatch.setattr(monitor, "strava_get", _fake_strava(
+        {"heart_rate": {"zones": HR_ZONES}, "power": {"zones": POWER_ZONES}}, STREAMS))
+    assert monitor.time_in_zone(1, "ride") == {"z1": 0, "z2": 1, "z3": 0, "z4": 0, "z5": 1}
+
+
+def test_walk_uses_heart_rate_zones(monkeypatch):
+    monkeypatch.setattr(monitor, "strava_get", _fake_strava(
+        {"heart_rate": {"zones": HR_ZONES}, "power": {"zones": POWER_ZONES}}, STREAMS))
+    assert monitor.time_in_zone(1, "walk") == {"z1": 0, "z2": 1, "z3": 0, "z4": 1, "z5": 0}
+
+
+def test_ride_without_power_zones_falls_back_to_heart_rate(monkeypatch):
+    monkeypatch.setattr(monitor, "strava_get", _fake_strava(
+        {"heart_rate": {"zones": HR_ZONES}}, STREAMS))
+    assert monitor.time_in_zone(1, "ride") == {"z1": 0, "z2": 1, "z3": 0, "z4": 1, "z5": 0}
 
 
 def test_finished_without_zone_context():


### PR DESCRIPTION
## Summary

Refactor zone scoring to use power zones for rides and heart rate zones for walks, with automatic fallback to heart rate when power data is unavailable. This aligns scoring with the athlete's actual training modality and Strava's zone system.

## Key Changes

- **Generalize `minutes_in_zone()`**: Extract zone bucketing logic into a reusable function that handles any stream (power or heart rate) against any zone list. Folds zones beyond z5 into z5 to match the contract's five-zone model.

- **Refactor `time_in_zone()`**: Change signature from `time_in_zone(activity_id, zones)` to `time_in_zone(activity_id, via)`. The function now:
  - Fetches both power and heart rate zones from Strava in one call
  - Selects the appropriate zone type based on activity type (`ride` → power, `walk` → heart rate)
  - Falls back to heart rate for rides missing power zones or watts stream, rather than returning None
  - Logs the fallback decision for visibility

- **Remove `hr_zones()`**: No longer needed; zone fetching is now integrated into `time_in_zone()`.

- **Update call site**: `run_morning.py` passes `y_via` instead of calling `monitor.hr_zones()`.

- **Add comprehensive tests**: Five new tests cover zone bucketing, fallback behavior, and activity-type-specific zone selection.

## Implementation Details

- The `minutes_in_zone()` function uses `min(z, 4)` to cap zone indices at 4 (z5), allowing Strava's extended power zone lists (up to z7) to fold into z5 without index errors.
- Pauses (dt > 60s) and None values in streams are skipped to avoid scoring gaps or missing data.
- The fallback logic tries power first for rides, then heart rate, ensuring rides always get scored when any zone data exists.

https://claude.ai/code/session_019p9AoKJBYx4sFjwUYmjUFF