### PR TITLE
morning.yml: optional date input for backfill runs

### DIFF
--- a/.github/workflows/morning.yml
+++ b/.github/workflows/morning.yml
@@ -9,6 +9,10 @@ on:
     # Late enough to sync the Oura ring first, still before the day's workout.
     - cron: '0 15 * 7 *'
   workflow_dispatch:
+    inputs:
+      date:
+        description: "Backfill: run as if today were YYYY-MM-DD (rescores the previous day's stage, skips the email)"
+        required: false
 
 jobs:
   morning:
@@ -38,7 +42,13 @@ jobs:
           EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
           TO_EMAIL: ${{ secrets.TO_EMAIL }}
           DASHBOARD_URL: https://alponsirenas.github.io/lanterne-rouge/
-        run: python run_morning.py
+          BACKFILL_DATE: ${{ inputs.date }}
+        run: |
+          if [ -n "$BACKFILL_DATE" ]; then
+            python run_morning.py --date "$BACKFILL_DATE" --no-email
+          else
+            python run_morning.py
+          fi
 
       - name: Persist rotated Strava token
         if: always()


### PR DESCRIPTION
## Summary

Adds an optional `date` input to the Morning Loop's manual dispatch. When set, the loop runs as if today were that day (`python run_morning.py --date <date> --no-email`), rescoring the previous day's stage without sending a stale email brief. A dispatch without the input behaves exactly as before.

This enables backfilling stages 1 and 2 with the power-zone scoring from #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019p9AoKJBYx4sFjwUYmjUFF

---
_Generated by [Claude Code](https://claude.ai/code/session_019p9AoKJBYx4sFjwUYmjUFF)_